### PR TITLE
feat: chat-tagging

### DIFF
--- a/app/(chat)/api/chat/[id]/tags/route.ts
+++ b/app/(chat)/api/chat/[id]/tags/route.ts
@@ -1,0 +1,50 @@
+import { auth } from '@/app/(auth)/auth';
+import { getChatById, updateChatTagsById } from '@/lib/db/queries';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const updateTagsSchema = z.object({
+  tags: z.array(z.string()),
+});
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const session = await auth();
+
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: chatId } = params;
+    const body = await request.json();
+
+    const { tags } = updateTagsSchema.parse(body);
+
+    // Check if chat exists and belongs to user
+    const chat = await getChatById({ id: chatId });
+    if (!chat) {
+      return NextResponse.json({ error: 'Chat not found' }, { status: 404 });
+    }
+
+    if (chat.userId !== session.user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Update the tags
+    const [updatedChat] = await updateChatTagsById({ chatId, tags });
+
+    return NextResponse.json({
+      success: true,
+      chat: updatedChat,
+    });
+  } catch (error) {
+    console.error('Failed to update chat tags:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/(chat)/api/chat/[id]/tags/route.ts
+++ b/app/(chat)/api/chat/[id]/tags/route.ts
@@ -9,7 +9,7 @@ const updateTagsSchema = z.object({
 
 export async function PUT(
   request: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const session = await auth();
@@ -18,7 +18,7 @@ export async function PUT(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { id: chatId } = params;
+    const { id: chatId } = await params;
     const body = await request.json();
 
     const { tags } = updateTagsSchema.parse(body);

--- a/components/chat/chat-tags-dialog.tsx
+++ b/components/chat/chat-tags-dialog.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
+import { X, Plus } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface ChatTagsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chatId: string;
+  currentTags: string[];
+  onTagsUpdated: () => void;
+}
+
+export function ChatTagsDialog({
+  open,
+  onOpenChange,
+  chatId,
+  currentTags,
+  onTagsUpdated,
+}: ChatTagsDialogProps) {
+  const [tags, setTags] = useState<string[]>(currentTags);
+  const [newTag, setNewTag] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const addTag = () => {
+    const trimmedTag = newTag.trim();
+    if (
+      trimmedTag &&
+      !tags.some((tag) => tag.toLowerCase() === trimmedTag.toLowerCase())
+    ) {
+      setTags([...tags, trimmedTag]);
+      setNewTag('');
+    }
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    setTags(tags.filter((tag) => tag !== tagToRemove));
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addTag();
+    }
+  };
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/chat/${chatId}/tags`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tags }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update tags');
+      }
+
+      toast.success('Tags updated successfully');
+      onTagsUpdated();
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Error updating tags:', error);
+      toast.error('Failed to update tags');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    setTags(currentTags); // Reset to original tags
+    setNewTag('');
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Manage Tags</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Current tags */}
+          <div className="space-y-2">
+            <Label>Current Tags</Label>
+            <div className="flex flex-wrap gap-2 min-h-[2rem]">
+              {tags.length === 0 ? (
+                <span className="text-sm text-muted-foreground">
+                  No tags added
+                </span>
+              ) : (
+                tags.map((tag) => (
+                  <Badge key={tag} variant="secondary" className="gap-1">
+                    {tag}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-4 w-4 p-0 hover:bg-transparent"
+                      onClick={() => removeTag(tag)}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </Badge>
+                ))
+              )}
+            </div>
+          </div>
+
+          {/* Add new tag */}
+          <div className="space-y-2">
+            <Label htmlFor="new-tag-input">Add New Tag</Label>
+            <div className="flex gap-2">
+              <Input
+                id="new-tag-input"
+                value={newTag}
+                onChange={(e) => setNewTag(e.target.value)}
+                onKeyDown={handleKeyPress}
+                placeholder="Enter a tag name"
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={addTag}
+                disabled={
+                  !newTag.trim() ||
+                  tags.some(
+                    (tag) => tag.toLowerCase() === newTag.trim().toLowerCase(),
+                  )
+                }
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={handleClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={isLoading}>
+            {isLoading ? 'Saving...' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/sidebar-history-item.tsx
+++ b/components/sidebar-history-item.tsx
@@ -68,7 +68,11 @@ const PureChatItem = ({
             <div className="flex flex-col items-start w-full gap-1">
               <span>{chat.title}</span>
               {(chat.tags?.length || 0) > 0 && (
-                <div className="flex flex-wrap gap-1" onClick={handleTagsClick}>
+                <button
+                  type="button"
+                  className="flex flex-wrap gap-1"
+                  onClick={handleTagsClick}
+                >
                   {displayedTags.map((tag) => (
                     <Badge
                       key={tag}
@@ -86,7 +90,7 @@ const PureChatItem = ({
                       +{remainingTagsCount} more
                     </Badge>
                   )}
-                </div>
+                </button>
               )}
             </div>
           </Link>

--- a/components/sidebar-history-item.tsx
+++ b/components/sidebar-history-item.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Chat } from '@/lib/db/schema';
 import {
   SidebarMenuAction,
@@ -23,96 +25,158 @@ import {
   ShareIcon,
   TrashIcon,
 } from './icons';
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { useChatVisibility } from '@/hooks/use-chat-visibility';
+import { Badge } from './ui/badge';
+import { ChatTagsDialog } from './chat/chat-tags-dialog';
+import { TagIcon } from 'lucide-react';
 
 const PureChatItem = ({
   chat,
   isActive,
   onDelete,
   setOpenMobile,
+  onUpdate,
 }: {
   chat: Chat;
   isActive: boolean;
   onDelete: (chatId: string) => void;
   setOpenMobile: (open: boolean) => void;
+  onUpdate?: () => void;
 }) => {
   const { visibilityType, setVisibilityType } = useChatVisibility({
     chatId: chat.id,
     initialVisibilityType: chat.visibility,
   });
 
+  const [tagsDialogOpen, setTagsDialogOpen] = useState(false);
+
+  const displayedTags = chat.tags?.slice(0, 2) || [];
+  const remainingTagsCount = (chat.tags?.length || 0) - displayedTags.length;
+
+  const handleTagsClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setTagsDialogOpen(true);
+  };
+
   return (
-    <SidebarMenuItem>
-      <SidebarMenuButton asChild isActive={isActive} size="flexi">
-        <Link href={`/chat/${chat.id}`} onClick={() => setOpenMobile(false)}>
-          <span>{chat.title}</span>
-        </Link>
-      </SidebarMenuButton>
+    <>
+      <SidebarMenuItem>
+        <SidebarMenuButton asChild isActive={isActive} size="flexi">
+          <Link href={`/chat/${chat.id}`} onClick={() => setOpenMobile(false)}>
+            <div className="flex flex-col items-start w-full gap-1">
+              <span>{chat.title}</span>
+              {(chat.tags?.length || 0) > 0 && (
+                <div className="flex flex-wrap gap-1" onClick={handleTagsClick}>
+                  {displayedTags.map((tag) => (
+                    <Badge
+                      key={tag}
+                      variant="outline"
+                      className="text-xs px-1 py-0 h-5"
+                    >
+                      {tag}
+                    </Badge>
+                  ))}
+                  {remainingTagsCount > 0 && (
+                    <Badge
+                      variant="outline"
+                      className="text-xs px-1 py-0 h-5 cursor-pointer"
+                    >
+                      +{remainingTagsCount} more
+                    </Badge>
+                  )}
+                </div>
+              )}
+            </div>
+          </Link>
+        </SidebarMenuButton>
 
-      <DropdownMenu modal={true}>
-        <DropdownMenuTrigger asChild>
-          <SidebarMenuAction
-            className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground mr-0.5"
-            showOnHover={!isActive}
-          >
-            <MoreHorizontalIcon />
-            <span className="sr-only">More</span>
-          </SidebarMenuAction>
-        </DropdownMenuTrigger>
+        <DropdownMenu modal={true}>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuAction
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground mr-0.5"
+              showOnHover={!isActive}
+            >
+              <MoreHorizontalIcon />
+              <span className="sr-only">More</span>
+            </SidebarMenuAction>
+          </DropdownMenuTrigger>
 
-        <DropdownMenuContent side="bottom" align="end">
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger className="cursor-pointer">
-              <ShareIcon />
-              <span>Share</span>
-            </DropdownMenuSubTrigger>
-            <DropdownMenuPortal>
-              <DropdownMenuSubContent>
-                <DropdownMenuItem
-                  className="cursor-pointer flex-row justify-between"
-                  onClick={() => {
-                    setVisibilityType('private');
-                  }}
-                >
-                  <div className="flex flex-row gap-2 items-center">
-                    <LockIcon size={12} />
-                    <span>Private</span>
-                  </div>
-                  {visibilityType === 'private' ? (
-                    <CheckCircleFillIcon />
-                  ) : null}
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  className="cursor-pointer flex-row justify-between"
-                  onClick={() => {
-                    setVisibilityType('public');
-                  }}
-                >
-                  <div className="flex flex-row gap-2 items-center">
-                    <GlobeIcon />
-                    <span>Public</span>
-                  </div>
-                  {visibilityType === 'public' ? <CheckCircleFillIcon /> : null}
-                </DropdownMenuItem>
-              </DropdownMenuSubContent>
-            </DropdownMenuPortal>
-          </DropdownMenuSub>
+          <DropdownMenuContent side="bottom" align="end">
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onClick={() => setTagsDialogOpen(true)}
+            >
+              <TagIcon size={16} />
+              <span>Edit Tags</span>
+            </DropdownMenuItem>
 
-          <DropdownMenuItem
-            className="cursor-pointer text-destructive focus:bg-destructive/15 focus:text-destructive dark:text-red-500"
-            onSelect={() => onDelete(chat.id)}
-          >
-            <TrashIcon />
-            <span>Delete</span>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </SidebarMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="cursor-pointer">
+                <ShareIcon />
+                <span>Share</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem
+                    className="cursor-pointer flex-row justify-between"
+                    onClick={() => {
+                      setVisibilityType('private');
+                    }}
+                  >
+                    <div className="flex flex-row gap-2 items-center">
+                      <LockIcon size={12} />
+                      <span>Private</span>
+                    </div>
+                    {visibilityType === 'private' ? (
+                      <CheckCircleFillIcon />
+                    ) : null}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="cursor-pointer flex-row justify-between"
+                    onClick={() => {
+                      setVisibilityType('public');
+                    }}
+                  >
+                    <div className="flex flex-row gap-2 items-center">
+                      <GlobeIcon />
+                      <span>Public</span>
+                    </div>
+                    {visibilityType === 'public' ? (
+                      <CheckCircleFillIcon />
+                    ) : null}
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+
+            <DropdownMenuItem
+              className="cursor-pointer text-destructive focus:bg-destructive/15 focus:text-destructive dark:text-red-500"
+              onSelect={() => onDelete(chat.id)}
+            >
+              <TrashIcon />
+              <span>Delete</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+
+      <ChatTagsDialog
+        open={tagsDialogOpen}
+        onOpenChange={setTagsDialogOpen}
+        chatId={chat.id}
+        currentTags={chat.tags || []}
+        onTagsUpdated={() => {
+          onUpdate?.();
+        }}
+      />
+    </>
   );
 };
 
 export const ChatItem = memo(PureChatItem, (prevProps, nextProps) => {
   if (prevProps.isActive !== nextProps.isActive) return false;
+  if (prevProps.chat.tags !== nextProps.chat.tags) return false;
   return true;
 });

--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -231,6 +231,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            onUpdate={mutate}
                           />
                         ))}
                       </div>
@@ -251,6 +252,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            onUpdate={mutate}
                           />
                         ))}
                       </div>
@@ -271,6 +273,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            onUpdate={mutate}
                           />
                         ))}
                       </div>
@@ -291,6 +294,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            onUpdate={mutate}
                           />
                         ))}
                       </div>
@@ -311,6 +315,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            onUpdate={mutate}
                           />
                         ))}
                       </div>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/lib/db/migrations/0007_daffy_energizer.sql
+++ b/lib/db/migrations/0007_daffy_energizer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Chat" ADD COLUMN "tags" text[] DEFAULT '{}' NOT NULL;

--- a/lib/db/migrations/meta/0007_snapshot.json
+++ b/lib/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,572 @@
+{
+  "id": "5c6a5cc2-3038-40e9-be35-16a9e4e395cd",
+  "prevId": "443de550-b7e8-4bfb-b229-c12dc6c132f0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1746118166211,
       "tag": "0006_marvelous_frog_thor",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1747986280694,
+      "tag": "0007_daffy_energizer",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -509,3 +509,22 @@ export async function getStreamIdsByChatId({ chatId }: { chatId: string }) {
     throw error;
   }
 }
+
+export async function updateChatTagsById({
+  chatId,
+  tags,
+}: {
+  chatId: string;
+  tags: string[];
+}) {
+  try {
+    return await db
+      .update(chat)
+      .set({ tags })
+      .where(eq(chat.id, chatId))
+      .returning();
+  } catch (error) {
+    console.error('Failed to update chat tags in database');
+    throw error;
+  }
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -29,6 +29,7 @@ export const chat = pgTable('Chat', {
   visibility: varchar('visibility', { enum: ['public', 'private'] })
     .notNull()
     .default('private'),
+  tags: text('tags').array().notNull().default([]),
 });
 
 export type Chat = InferSelectModel<typeof chat>;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",
-    "build": "tsx lib/db/migrate && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "biome lint --write --unsafe",
     "lint:fix": "biome lint --write --unsafe",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",
-    "build": "next build",
+    "build": "tsx lib/db/migrate && next build",
     "start": "next start",
     "lint": "biome lint --write --unsafe",
     "lint:fix": "biome lint --write --unsafe",

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,85 @@
+## Chat Tagging Feature Implementation Plan
+
+### 1. Database Schema Modification
+
+- **File**: `lib/db/schema.ts`
+- **Table**: `chat`
+- **Action**: Add a new column named `tags`.
+  - **Type**: `text[]` (array of strings). This column will store an array of strings, e.g., `['work', 'urgent', 'project-x']`.
+  - **Default**: `[]` (empty array).
+  - **Nullable**: `false` (tags should always be an array, even if empty).
+
+### 2. Backend API Endpoints
+
+- **Location**: Create a new API route handler, e.g., `app/(chat)/api/chat/[id]/tags/route.ts`.
+- **Endpoint**:
+  - `PUT /api/chat/[id]/tags`
+    - **Request Body**: `{ tags: string[] }`
+    - **Action**: Updates the `tags` field for the specified `chatId`.
+    - Performs validation (e.g., ensure `tags` is an array of strings).
+    - Returns a success or error response.
+    - The client-side will be responsible for re-fetching data after a successful update.
+
+### 3. UI Components
+
+#### 3.1. Tag Management Dialog
+
+- **New Component**: `components/chat/chat-tags-dialog.tsx`
+- **Functionality**:
+  - Triggered by the "Edit Tags" button and the "+X more" indicator.
+  - Receives `chatId` and current `tags` as props.
+  - Displays existing tags for the chat. Each tag should have a remove button (e.g., an 'x' icon).
+  - Contains an input field for adding new tags:
+    - Users can type a tag and press "Enter" to add it.
+    - A dedicated "Add Tag" button next to the input field will also add the current input value as a tag.
+    - Prevent duplicate tags (case-insensitive check, but store with original casing or normalize to lowercase).
+  - On "Save" or "Done", calls the `PUT /api/chat/[id]/tags` endpoint.
+  - Handles loading and error states. Manages client-side state for tags during editing.
+  - After a successful update, triggers a data re-fetch for the chat list or relevant chat items.
+- **Styling**: Use `shadcn/ui` components (`Dialog`, `Input`, `Button`, `Badge` for displaying tags).
+
+#### 3.2. Chat Item UI Update
+
+- **File**: `components/sidebar-history-item.tsx`
+- **Modifications**:
+  - **Action Menu**:
+    - Add a new `DropdownMenuItem` labeled "Edit Tags".
+    - This item will open the `ChatTagsDialog`, passing the `chat.id` and `chat.tags`.
+  - **Tag Display**:
+    - Below the chat title (`<span>{chat.title}</span>`), add a new section to display tags.
+    - Fetch `tags` along with other chat data.
+    - Display up to 3 tags (e.g., using `Badge` components).
+    - If more than 3 tags exist, display the first 2 tags and a "+N more" indicator (e.g., `+${chat.tags.length - 2} more`).
+    - The "+N more" indicator should be clickable and open the `ChatTagsDialog` for that chat.
+    - If no tags, this section should not render or take up space.
+
+### 4. Data Fetching
+
+- **File**: Likely in `app/(chat)/chat/[id]/page.tsx` or `components/sidebar-history.tsx` or wherever chat list data is fetched.
+- **Action**:
+  - Ensure the `tags` field is included when fetching chat data. Modify Drizzle queries accordingly.
+  - Implement client-side logic to re-fetch chat data (e.g., the list of chats in the sidebar) after tags are successfully updated via the API. This could involve using a data fetching library's cache invalidation/refetch mechanism or a simple manual refetch.
+
+### 5. State Management (Client-Side)
+
+- The `ChatTagsDialog` will manage its own internal state for the list of tags being edited.
+- Global state management or context might be used to trigger a refresh of the chat list if not handled by a data fetching library's automatic Caching/SWR capabilities.
+
+### 6. Styling and UX
+
+- Ensure the new UI elements are consistent with the existing design (`shadcn/ui`, Tailwind CSS).
+- Provide clear visual feedback for adding/removing tags in the dialog.
+- Consider edge cases: empty input, very long tags.
+
+### Implementation Order Suggestion
+
+1.  Update database schema (`lib/db/schema.ts`) and run migrations.
+2.  Implement the backend API endpoint (`PUT /api/chat/[id]/tags`).
+3.  Create the basic `ChatTagsDialog` component (structure, state, and API call integration).
+4.  Implement client-side data re-fetching logic upon successful tag update.
+5.  Integrate `ChatTagsDialog` with the "Edit Tags" button in `components/sidebar-history-item.tsx`.
+6.  Implement tag display (up to 3, "+N more") in `components/sidebar-history-item.tsx`.
+7.  Connect "+N more" to open `ChatTagsDialog`.
+8.  Refine styling and UX.
+
+This plan provides a structured approach to implementing the chat tagging feature.


### PR DESCRIPTION
### What has been done?

- Add chat tagging functionality to chats

This is a sample changes to demo the flow of plan -> implementation in Cursor agent mode. Plan is a custom mode which has it's own instruction prompt to make a plan. I prefer using Gemini 2.5 pro for planning. Act is simply Agent mode using Claude 3.7 (now Claude 4).

In this PR, you can see `plan.md` which generated by "Plan" mode. During this mode, it's best to focus on clarification and making a clear plan for Agent to work on. Try not to include code example in "Plan" as it often mis-gude agent during implementation mode.

All code was generated using Agent with Claude 3.7 / 4 by referencing plan.md with only 1 request. I didn't review the code or make any modification (but in real use case you should definitely cross check agent output).
